### PR TITLE
corretto21

### DIFF
--- a/Casks/corretto21.rb
+++ b/Casks/corretto21.rb
@@ -1,0 +1,25 @@
+cask "corretto21" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "21.0.0.35.1"
+  sha256 arm:   "4a877d133a3c2c524947a53f5f031cb87264c18c97c858acb084bbf8bf4e476c",
+         intel: "0201f564f99225e132399d358c52e80fe97945175d95681249741d6654e099e0"
+
+  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
+  name "AWS Corretto JDK"
+  desc "OpenJDK distribution from Amazon"
+  homepage "https://corretto.aws/"
+
+  livecheck do
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
+    strategy :header_match do |headers|
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
+    end
+  end
+
+  pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
+
+  uninstall pkgutil: "com.amazon.corretto.#{version.major}"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
JDK 21 is the next LTS release of the Java Platform. Corretto 21 matches the Corretto 17, 11, and 8 casks already a part of this repo. This is currently a copy of the `corretto` formula with 21 added to the token, so that as JDK 22 starts development, this is a stable target for those that want the latest LTS release.
